### PR TITLE
feat: Change launch URL from Swagger to API endpoint

### DIFF
--- a/src/RO.DevTest.WebApi/Controllers/HomeController.cs
+++ b/src/RO.DevTest.WebApi/Controllers/HomeController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using NSwag.Annotations;
+using RO.DevTest.Domain.Abstract;
+
+namespace RO.DevTest.WebApi.Controllers;
+
+[ApiController]
+[Route("/api")]
+[OpenApiTags("Health System")]
+[ApiExplorerSettings(GroupName = "Monitoring and Diagnostics")]
+public class HomeController : ControllerBase
+{
+    [HttpGet]
+    [Route("")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [OpenApiOperation("Check Availability", "Confirms if the system is operational")]
+    public IActionResult CheckAvailability()
+        => Ok(Result<dynamic>.Success(null, messages: "System is operational and responding normally"));
+}

--- a/src/RO.DevTest.WebApi/Properties/launchSettings.json
+++ b/src/RO.DevTest.WebApi/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "api",
       "applicationUrl": "http://localhost:5087",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
- Modified launch settings to open the browser directly at the /api endpoint instead of Swagger UI
- This change provides faster access to the health check endpoint during development
- Swagger documentation remains accessible at /swagger for API exploration