### PR TITLE
feat(repository): add GetQueryable method to BaseRepository for flexible queries

### DIFF
--- a/src/RO.DevTest.Application/Contracts/Persistance/Repositories/IBaseRepository.cs
+++ b/src/RO.DevTest.Application/Contracts/Persistance/Repositories/IBaseRepository.cs
@@ -30,6 +30,21 @@ public interface IBaseRepository<T> where T : class
     /// <param name="entity">The entity to update</param>
     Task UpdateAsync(T entity, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns an <see cref="IQueryable{T}"/> for further query composition,
+    /// with optional includes for navigation properties.
+    /// </summary>
+    /// <param name="predicate">The filter expression to apply.</param>
+    /// <param name="includes">
+    /// Optional related entities to include in the query results.
+    /// Useful for eager loading of navigation properties.
+    /// </param>
+    /// <returns>
+    /// A queryable collection of <typeparamref name="T"/> that matches the given predicate,
+    /// with optional navigation properties included.
+    /// </returns>
+
+    IQueryable<T> GetQueryable(Expression<Func<T, bool>> predicate, params Expression<Func<T, object>>[] includes);
 
     /// <summary>
     /// Deletes one entry from the database

--- a/src/RO.DevTest.Persistence/Repositories/BaseRepository.cs
+++ b/src/RO.DevTest.Persistence/Repositories/BaseRepository.cs
@@ -8,6 +8,7 @@ public class BaseRepository<T>(DefaultContext context)
     : IBaseRepository<T> where T : class
 {
     private DbSet<T> Table { get; } = context.Set<T>();
+
     public async Task<T> CreateAsync(T entity, CancellationToken cancellationToken = default)
     {
         await Table.AddAsync(entity, cancellationToken);
@@ -29,12 +30,19 @@ public class BaseRepository<T>(DefaultContext context)
 
     public async Task<T?> GetAsync(
         CancellationToken cancellationToken,
-        Expression<Func<T, bool>> predicate, 
+        Expression<Func<T, bool>> predicate,
         params Expression<Func<T, object>>[] includes
     )
         => await GetQueryWithIncludes(predicate, includes)
             .AsNoTracking()
             .FirstOrDefaultAsync(cancellationToken);
+
+    public IQueryable<T> GetQueryable(
+        Expression<Func<T, bool>> predicate,
+        params Expression<Func<T, object>>[] includes
+    )
+        => GetQueryWithIncludes(predicate, includes)
+            .AsNoTracking();
 
     /// <summary>
     /// Generates a filtered <see cref="IQueryable{T}"/>, based on its
@@ -76,10 +84,7 @@ public class BaseRepository<T>(DefaultContext context)
     private IQueryable<T> GetWhereQuery(Expression<Func<T, bool>> predicate)
     {
         IQueryable<T> baseQuery = Table;
-
-        if (predicate is not null)
-            baseQuery = baseQuery.Where(predicate);
-
+        baseQuery = baseQuery.Where(predicate);
         return baseQuery;
     }
 }


### PR DESCRIPTION
Introduced GetQueryable to enable custom query composition with filters and includes. This will allow consumers to perform pagination, ordering, and additional filters outside of the repository layer, improving flexibility and reusability.