### PR TITLE
feat: implement sale deletion functionality

### DIFF
--- a/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommand.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using RO.DevTest.Domain.Abstract;
+
+namespace RO.DevTest.Application.Features.Sale.Commands.DeleteSaleCommand;
+
+public record DeleteSaleCommand (Guid SaleId) : IRequest<Result<DeleteSaleResponse>>;

--- a/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommandHandler.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommandHandler.cs
@@ -1,0 +1,48 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using RO.DevTest.Application.Contracts.Infrastructure.Services;
+using RO.DevTest.Application.Contracts.Persistance.Repositories;
+using RO.DevTest.Domain.Abstract;
+
+namespace RO.DevTest.Application.Features.Sale.Commands.DeleteSaleCommand;
+
+public class DeleteSaleCommandHandler(
+    ISaleRepository saleRepository,
+    IValidator<DeleteSaleCommand> validator,
+    ICurrentUserService currentUserService,
+    ILogger<DeleteSaleCommandHandler> logger)
+    : IRequestHandler<DeleteSaleCommand, Result<DeleteSaleResponse>>
+{
+    public async Task<Result<DeleteSaleResponse>> Handle(DeleteSaleCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var validationResult = await validator.ValidateAsync(request, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                return Result<DeleteSaleResponse>.Failure(messages:
+                    validationResult.Errors.Select(e => e.ErrorMessage).ToArray());
+            }
+            
+            var sale = await saleRepository.GetAsync(
+                cancellationToken,
+                p => p.Id == request.SaleId
+                     && p.DeletedAt == null
+                     && p.CustomerId == Guid.Parse(currentUserService.GetCurrentUserId()));
+            
+            if (sale is null)
+                return Result<DeleteSaleResponse>.Failure(messages: "Purchase not found");
+            
+            sale.DeletedAt = DateTime.Now;
+            await saleRepository.UpdateAsync(sale, cancellationToken);
+            return Result<DeleteSaleResponse>.Success(new DeleteSaleResponse(sale), messages: "Deleted purchase");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex.Message);
+            return Result<DeleteSaleResponse>.Failure(StatusCodes.Status500InternalServerError, ex.Message);
+        }
+    }
+}

--- a/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommandValidator.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace RO.DevTest.Application.Features.Sale.Commands.DeleteSaleCommand;
+
+public class DeleteSaleCommandValidator : AbstractValidator<DeleteSaleCommand>
+{
+    public DeleteSaleCommandValidator()
+    {
+        RuleFor(s => s.SaleId)
+            .NotEmpty()
+            .WithMessage("Id da compra é obrigatório");
+    }
+}

--- a/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleResponse.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleResponse.cs
@@ -1,0 +1,19 @@
+using RO.DevTest.Domain.Extensions;
+
+namespace RO.DevTest.Application.Features.Sale.Commands.DeleteSaleCommand;
+
+public record DeleteSaleResponse
+{
+    public Guid SaleId { get; init; }
+    public DateTime TransactionDate { get; init; }
+    public string PaymentMethod { get; init; }
+    public decimal TotalPrice { get; init; }
+
+    public DeleteSaleResponse(Domain.Entities.Sale sale)
+    {
+        SaleId = sale.Id;
+        TransactionDate = sale.TransactionDate;
+        PaymentMethod = sale.PaymentMethod.GetDescription();
+        TotalPrice = sale.TotalPrice;
+    }
+}

--- a/src/RO.DevTest.Application/RO.DevTest.Application.csproj
+++ b/src/RO.DevTest.Application/RO.DevTest.Application.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Features\Sale\Commands\DeleteSaleCommand\" />
     <Folder Include="Features\Sale\Queries\" />
   </ItemGroup>
 

--- a/src/RO.DevTest.WebApi/Controllers/SaleController.cs
+++ b/src/RO.DevTest.WebApi/Controllers/SaleController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using NSwag.Annotations;
 using RO.DevTest.Application.Features.Sale.Commands.CreateSaleCommand;
+using RO.DevTest.Application.Features.Sale.Commands.DeleteSaleCommand;
 using RO.DevTest.Application.Features.Sale.Commands.UpdateSaleCommand;
 using RO.DevTest.Domain.Abstract;
 
@@ -45,6 +46,21 @@ public class SaleController(IMediator mediator) : ControllerBase
     [ProducesResponseType(typeof(Result<UpdateSaleResponse>), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateSale(
         [FromBody] UpdateSaleCommand request,
+        CancellationToken cancellationToken)
+    {
+        var response = await mediator.Send(request, cancellationToken);
+        return StatusCode(response.StatusCode, response);
+    }
+    
+    [HttpDelete]
+    [Authorize]
+    [Route("")]
+    [ActionName("DeleteSale")]
+    [ProducesResponseType(typeof(Result<DeleteSaleResponse>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(Result<DeleteSaleResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(Result<DeleteSaleResponse>), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> DeleteSale(
+        [FromBody] DeleteSaleCommand request,
         CancellationToken cancellationToken)
     {
         var response = await mediator.Send(request, cancellationToken);


### PR DESCRIPTION
- Add DeleteSaleCommand and related classes to enable soft deletion of sales
- Implement DELETE endpoint in SaleController for removing sales
- Use soft delete approach by setting DeletedAt timestamp instead of physical deletion
- Verify sale ownership before deletion for security
- Branch: feature/sale-delete