### PR TITLE
feat: Add unit tests for Sale command handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# API de E-commerce - Teste Técnico Rota das Oficinas
+**# API de E-commerce - Teste Técnico Rota das Oficinas
 
-Olá! Me chamo Samuel Ribeiro e quero apresentar minha solução para o teste técnico da Rota das Oficinas: uma API de e-commerce em .NET 8 que gerencia clientes, produtos e vendas com autenticação JWT, paginação avançada e análise de dados. Implementei testes unitários abrangentes e segui as melhores práticas de arquitetura, garantindo código limpo e funcional para todos os requisitos solicitados.
+Olá! Me chamo Samuel Ribeiro e quero apresentar minha solução para o teste técnico da Rota das Oficinas: uma API de e-commerce em .NET 8 que gerencia clientes, produtos e vendas com autenticação JWT, paginação e análise de dados. Implementei testes unitários abrangentes e segui as melhores práticas de arquitetura, garantindo código limpo e funcional para todos os requisitos solicitados.
 
 ## Executando a API
 
@@ -56,9 +56,11 @@ openssl pkcs12 -export -out jwt-key.pfx -inkey private_key.pem -in certificate.p
 
 2. Commando para rodar a API com o Docker Compose
 ```bash
-"Windows:" docker-compose up -d
-"Linux Ubuntu:" docker compose up -d
+"Windows:" docker-compose up --build -d
+"Linux Ubuntu:" docker compose up --build -d
 ```
+> **Nota:** Após o container da WebApi rodar é necessário esperar cerca de 10 segundos para aplicação dentro do 
+> container iniciar, por causa do `sleep 10` no entrypoint.sh
 
 ### ⚙️ Executando Localmente (Sem Docker Compose)
 
@@ -275,4 +277,4 @@ A API oferece um conjunto completo de endpoints para gerenciamento e análise de
       - Parâmetros de consulta: período para análise (startDate, endDate)
       - Retorno: Dados agregados incluindo valor total, quantidade de itens, número de transações e lista dos 5 produtos mais vendidos no período
 
-   - **Nota**: Todos os endpoints necessitam da view SQL `vw_admin_product_monthly_sales` para funcionamento correto
+   - **Nota**: Todos os endpoints necessitam da view SQL `vw_admin_product_monthly_sales` para funcionamento correto**

--- a/src/RO.DevTest.Application/Features/Sale/Commands/CreateSaleCommand/CreateSaleCommandHandler.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/CreateSaleCommand/CreateSaleCommandHandler.cs
@@ -52,6 +52,7 @@ public class CreateSaleCommandHandler(
             await saleRepository.CreateAsync(sale, cancellationToken);
             product.AvailableQuantity -= request.Quantity;
             await productRepository.UpdateAsync(product, cancellationToken);
+            
             var completeSale = await saleRepository.GetAsync(
                 cancellationToken,
                 s => s.Id == sale.Id,

--- a/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommandHandler.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/DeleteSaleCommand/DeleteSaleCommandHandler.cs
@@ -35,7 +35,7 @@ public class DeleteSaleCommandHandler(
                      && p.CustomerId == Guid.Parse(currentUserService.GetCurrentUserId()));
             
             if (sale is null)
-                return Result<DeleteSaleResponse>.Failure(messages: "Compra não encontrada.");
+                return Result<DeleteSaleResponse>.Failure(StatusCodes.Status404NotFound, messages: "Compra não encontrada.");
 
             var product = await productRepository.GetAsync(
                 cancellationToken, 
@@ -43,7 +43,7 @@ public class DeleteSaleCommandHandler(
                 && p.DeletedAt == null);
 
             if (product is null)
-                return Result<DeleteSaleResponse>.Failure(messages: "Você não pode excluir a compra porque o produto não está mais disponível.");
+                return Result<DeleteSaleResponse>.Failure(StatusCodes.Status404NotFound, messages: "Você não pode excluir a compra porque o produto não está mais disponível.");
  
             using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
             {

--- a/src/RO.DevTest.Application/Features/Sale/Commands/UpdateSaleCommand/UpdateSaleCommandHandler.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/UpdateSaleCommand/UpdateSaleCommandHandler.cs
@@ -33,7 +33,7 @@ public class UpdateSaleCommandHandler(
                      && p.CustomerId == Guid.Parse(currentUserService.GetCurrentUserId()));
 
             if (sale is null)
-                return Result<UpdateSaleResponse>.Failure(messages: "Compra não encontrada");
+                return Result<UpdateSaleResponse>.Failure(StatusCodes.Status404NotFound ,messages: "Compra não encontrada");
 
             sale.EPaymentMethod = request.EPaymentMethod;
             sale.ModifiedOn = DateTime.Now;

--- a/src/RO.DevTest.Application/Features/Sale/Commands/UpdateSaleCommand/UpdateSaleCommandValidator.cs
+++ b/src/RO.DevTest.Application/Features/Sale/Commands/UpdateSaleCommand/UpdateSaleCommandValidator.cs
@@ -12,7 +12,7 @@ public class UpdateSaleCommandValidator : AbstractValidator<UpdateSaleCommand>
         
         RuleFor(s => s.EPaymentMethod)
             .NotNull()
-            .WithMessage("O método de pagamento é obrigastório")
+            .WithMessage("O método de pagamento é obrigatório")
             .IsInEnum()
             .WithMessage("Método de pagamento inválido");
     }

--- a/src/RO.DevTest.Tests/Unit/Application/Features/Sale/Commands/CreateSaleCommandHandlerTests.cs
+++ b/src/RO.DevTest.Tests/Unit/Application/Features/Sale/Commands/CreateSaleCommandHandlerTests.cs
@@ -1,0 +1,226 @@
+using System.Linq.Expressions;
+using Bogus;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RO.DevTest.Application.Contracts.Infrastructure.Services;
+using RO.DevTest.Application.Contracts.Persistance.Repositories;
+using RO.DevTest.Application.Features.Sale.Commands.CreateSaleCommand;
+using RO.DevTest.Domain.Enums;
+
+namespace RO.DevTest.Tests.Unit.Application.Features.Sale.Commands;
+
+public class CreateSaleCommandHandlerTests
+{
+    private readonly Mock<ISaleRepository> _mockSaleRepository;
+    private readonly Mock<IProductRepository> _mockProductRepository;
+    private readonly Mock<IValidator<CreateSaleCommand>> _mockValidator;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<ILogger<CreateSaleCommandHandler>> _mockLogger;
+    private readonly CreateSaleCommandHandler _handler;
+
+    public CreateSaleCommandHandlerTests()
+    {
+        _mockSaleRepository = new Mock<ISaleRepository>();
+        _mockProductRepository = new Mock<IProductRepository>();
+        _mockValidator = new Mock<IValidator<CreateSaleCommand>>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+        _mockLogger = new Mock<ILogger<CreateSaleCommandHandler>>();
+
+        _handler = new CreateSaleCommandHandler(
+            _mockSaleRepository.Object,
+            _mockProductRepository.Object,
+            _mockValidator.Object,
+            _mockCurrentUserService.Object,
+            _mockLogger.Object
+        );
+    }
+
+    [Fact(DisplayName = "Should create a valid sale when all inputs are correct")]
+    public async Task Handle_WithValidInput_ShouldCreateSaleSuccessfully()
+    {
+        // Arrange
+        var admin = new Domain.Entities.Identity.User
+        {
+            Id = new Faker().Random.Guid(),
+            Name = new Faker().Name.FullName()
+        };
+
+        var customer = new Domain.Entities.Identity.User
+        {
+            Id = new Faker().Random.Guid(),
+            Name = new Faker().Name.FullName()
+        };
+
+        var existingProduct = new Domain.Entities.Product
+        {
+            Id = new Faker().Random.Guid(),
+            Name = new Faker().Commerce.ProductName(),
+            Description = new Faker().Commerce.ProductDescription(),
+            UnitPrice = new Faker().Random.Decimal(9.99m, 599.99m),
+            AvailableQuantity = new Faker().Random.Int(20, 100),
+            EProductCategory = EProductCategory.Automotive,
+            AdminId = admin.Id
+        };
+
+        var command = new CreateSaleCommand(
+            existingProduct.Id,
+            new Faker().PickRandom<EPaymentMethod>(),
+            new Faker().Random.Int(2, 15)
+        );
+
+        var newSale = new Domain.Entities.Sale
+        {
+            Id = new Faker().Random.Guid(),
+            AdminId = admin.Id,
+            Admin = admin,
+            ProductId = existingProduct.Id,
+            Product = existingProduct,
+            CustomerId = customer.Id,
+            Customer = customer,
+            EPaymentMethod = command.EPaymentMethod,
+            Quantity = command.Quantity,
+            UnitPrice = existingProduct.UnitPrice
+        };
+
+        _mockValidator
+            .Setup(va => va.ValidateAsync(
+                It.IsAny<CreateSaleCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockCurrentUserService
+            .Setup(cs => cs.IsAdmin())
+            .Returns(false);
+        
+        _mockCurrentUserService
+            .Setup(cs => cs.GetCurrentUserId())
+            .Returns(customer.Id.ToString());
+
+        _mockProductRepository
+            .Setup(pr => pr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, object>>[]>()))
+            .ReturnsAsync(existingProduct);
+
+        _mockSaleRepository
+            .Setup(sr => sr.CreateAsync(
+                It.IsAny<Domain.Entities.Sale>(),
+                It.IsAny<CancellationToken>()));
+
+        _mockSaleRepository
+            .Setup(pr => pr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, object>>[]>()))
+            .ReturnsAsync(newSale);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.StatusCode.Should().Be(StatusCodes.Status201Created);
+        result.Message.Should().ContainSingle().Which.Should().Be("Compra realizada com sucesso");
+    }
+    
+    [Fact(DisplayName = "Should return failure when product is out of stock")]
+    public async Task Handle_WithProductOutOfStock_ShouldReturnFailure()
+    {
+        // Arrange
+        var existingProduct = new Domain.Entities.Product
+        {
+            Id = new Faker().Random.Guid(),
+            Name = new Faker().Commerce.ProductName(),
+            Description = new Faker().Commerce.ProductDescription(),
+            UnitPrice = new Faker().Random.Decimal(9.99m, 599.99m),
+            AvailableQuantity = 0,
+            EProductCategory = EProductCategory.Automotive,
+            AdminId = new Faker().Random.Guid()
+        };
+
+        var command = new CreateSaleCommand(
+            existingProduct.Id,
+            new Faker().PickRandom<EPaymentMethod>(),
+            new Faker().Random.Int(11, 15)
+        );
+        
+        _mockValidator
+            .Setup(va => va.ValidateAsync(
+                It.IsAny<CreateSaleCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockCurrentUserService
+            .Setup(cs => cs.IsAdmin())
+            .Returns(false);
+        
+        _mockProductRepository
+            .Setup(pr => pr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, object>>[]>()))
+            .ReturnsAsync(existingProduct);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Data.Should().BeNull();
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        result.Message.Should().ContainSingle().Which.Should().Be("Produto fora de estoque");
+    }
+
+    [Fact(DisplayName = "Should return failure when product quantity is insufficient")]
+    public async Task Handle_WithInsufficientProductQuantity_ShouldReturnFailure()
+    {
+        // Arrange
+        var existingProduct = new Domain.Entities.Product
+        {
+            Id = new Faker().Random.Guid(),
+            Name = new Faker().Commerce.ProductName(),
+            Description = new Faker().Commerce.ProductDescription(),
+            UnitPrice = new Faker().Random.Decimal(9.99m, 599.99m),
+            AvailableQuantity = new Faker().Random.Int(5, 10),
+            EProductCategory = EProductCategory.Automotive,
+            AdminId = new Faker().Random.Guid()
+        };
+
+        var command = new CreateSaleCommand(
+            existingProduct.Id,
+            new Faker().PickRandom<EPaymentMethod>(),
+            new Faker().Random.Int(16, 20)
+        );
+        
+        _mockValidator
+            .Setup(va => va.ValidateAsync(
+                It.IsAny<CreateSaleCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockCurrentUserService
+            .Setup(cs => cs.IsAdmin())
+            .Returns(false);
+        
+        _mockProductRepository
+            .Setup(pr => pr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, object>>[]>()))
+            .ReturnsAsync(existingProduct);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Data.Should().BeNull();
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        result.Message.Should().ContainSingle().Which.Should().Be("Quantidade insuficiente disponível");
+    }
+}

--- a/src/RO.DevTest.Tests/Unit/Application/Features/Sale/Commands/DeleteSaleCommandHandlerTests.cs
+++ b/src/RO.DevTest.Tests/Unit/Application/Features/Sale/Commands/DeleteSaleCommandHandlerTests.cs
@@ -1,0 +1,185 @@
+using System.Linq.Expressions;
+using Bogus;
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RO.DevTest.Application.Contracts.Infrastructure.Services;
+using RO.DevTest.Application.Contracts.Persistance.Repositories;
+using RO.DevTest.Application.Features.Sale.Commands.DeleteSaleCommand;
+using RO.DevTest.Domain.Enums;
+
+namespace RO.DevTest.Tests.Unit.Application.Features.Sale.Commands;
+
+public class DeleteSaleCommandHandlerTests
+{
+    private readonly Mock<ISaleRepository> _mockSaleRepository;
+    private readonly Mock<IProductRepository> _mockProductRepository;
+    private readonly Mock<IValidator<DeleteSaleCommand>> _mockValidator;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<ILogger<DeleteSaleCommandHandler>> _mockLogger;
+    private readonly DeleteSaleCommandHandler _handler;
+
+    public DeleteSaleCommandHandlerTests()
+    {
+        _mockSaleRepository = new Mock<ISaleRepository>();
+        _mockProductRepository = new Mock<IProductRepository>();
+        _mockValidator = new Mock<IValidator<DeleteSaleCommand>>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+        _mockLogger = new Mock<ILogger<DeleteSaleCommandHandler>>();
+
+        _handler = new DeleteSaleCommandHandler(
+            _mockSaleRepository.Object,
+            _mockProductRepository.Object,
+            _mockValidator.Object,
+            _mockCurrentUserService.Object,
+            _mockLogger.Object
+        );
+    }
+
+    [Fact(DisplayName = "Should delete sale successfully when all inputs are correct")]
+    public async Task Handle_WithValidInput_ShouldDeleteSaleSuccessfully()
+    {
+        // Arrange
+        var existingSale = new Domain.Entities.Sale
+        {
+            Id = new Faker().Random.Guid(),
+            CustomerId = new Faker().Random.Guid(),
+            ProductId = new Faker().Random.Guid(),
+            Quantity = new Faker().Random.Int(20, 40),
+            UnitPrice = new Faker().Random.Decimal(9.99m, 599.99m),
+            EPaymentMethod = new Faker().PickRandom<EPaymentMethod>()
+        };
+
+        var existingProduct = new Domain.Entities.Product
+        {
+            Id = existingSale.ProductId,
+            AvailableQuantity = new Faker().Random.Int(20, 100),
+            Name = new Faker().Commerce.ProductName(),
+            UnitPrice = new Faker().Random.Decimal(9.99m, 599.99m)
+        };
+
+        var command = new DeleteSaleCommand(existingSale.Id);
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<DeleteSaleCommand>(), 
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockCurrentUserService
+            .Setup(cs => cs.GetCurrentUserId())
+            .Returns(existingSale.CustomerId.ToString());
+
+        _mockSaleRepository
+            .Setup(sr => sr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, object>>[]>()))
+            .ReturnsAsync(existingSale);
+
+        _mockProductRepository
+            .Setup(pr => pr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, object>>[]>()))
+            .ReturnsAsync(existingProduct);
+
+        _mockSaleRepository
+            .Setup(sr => sr.UpdateAsync(It.IsAny<Domain.Entities.Sale>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockProductRepository
+            .Setup(pr => pr.UpdateAsync(It.IsAny<Domain.Entities.Product>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Data.Should().NotBeNull();
+        result.Message.Should().ContainSingle().Which.Should().Be("Compra excluída com sucesso.");
+    }
+    
+    [Fact(DisplayName = "Should return failure when sale is not found or belongs to another customer")]
+    public async Task Handle_WithNonExistentSale_ShouldReturnFailure()
+    {
+        // Arrange
+        var command = new DeleteSaleCommand(new Faker().Random.Guid());
+        
+        _mockValidator
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<DeleteSaleCommand>(), 
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+        
+        _mockSaleRepository
+            .Setup(sr => sr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, object>>[]>()))
+            .ReturnsAsync((Domain.Entities.Sale)null!);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        result.Data.Should().BeNull();
+        result.Message.Should().ContainSingle().Which.Should().Be("Compra não encontrada.");
+    }
+    
+    [Fact(DisplayName = "Should return failure when associated product is no longer available")]
+    public async Task Handle_WithUnavailableProduct_ShouldReturnFailure()
+    {
+        // Arrange
+        var existingSale = new Domain.Entities.Sale
+        {
+            Id = new Faker().Random.Guid(),
+            CustomerId = new Faker().Random.Guid(),
+            ProductId = new Faker().Random.Guid(),
+            Quantity = new Faker().Random.Int(20, 40),
+            UnitPrice = new Faker().Random.Decimal(9.99m, 599.99m),
+            EPaymentMethod = new Faker().PickRandom<EPaymentMethod>()
+        };
+
+        var command = new DeleteSaleCommand(existingSale.Id);
+
+        _mockValidator
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<DeleteSaleCommand>(), 
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockCurrentUserService
+            .Setup(cs => cs.GetCurrentUserId())
+            .Returns(existingSale.CustomerId.ToString());
+
+        _mockSaleRepository
+            .Setup(sr => sr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, object>>[]>()))
+            .ReturnsAsync(existingSale);
+
+        _mockProductRepository
+            .Setup(pr => pr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Product, object>>[]>()))
+            .ReturnsAsync((Domain.Entities.Product)null!);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        result.Data.Should().BeNull();
+        result.Message.Should().ContainSingle().Which.Should().Be("Você não pode excluir a compra porque o produto não está mais disponível.");
+    }
+}

--- a/src/RO.DevTest.Tests/Unit/Application/Features/Sale/Commands/UpdateSaleCommandHandlerTests.cs
+++ b/src/RO.DevTest.Tests/Unit/Application/Features/Sale/Commands/UpdateSaleCommandHandlerTests.cs
@@ -1,0 +1,159 @@
+using System.Linq.Expressions;
+using Bogus;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RO.DevTest.Application.Contracts.Infrastructure.Services;
+using RO.DevTest.Application.Contracts.Persistance.Repositories;
+using RO.DevTest.Application.Features.Sale.Commands.UpdateSaleCommand;
+using RO.DevTest.Domain.Enums;
+
+namespace RO.DevTest.Tests.Unit.Application.Features.Sale.Commands;
+
+public class UpdateSaleCommandHandlerTests
+{
+    private readonly Mock<ISaleRepository> _mockSaleRepository;
+    private readonly Mock<IValidator<UpdateSaleCommand>> _mockValidator;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<ILogger<UpdateSaleCommandHandler>> _mockLogger;
+    private readonly UpdateSaleCommandHandler _handler;
+
+    public UpdateSaleCommandHandlerTests()
+    {
+        _mockSaleRepository = new Mock<ISaleRepository>();
+        _mockValidator = new Mock<IValidator<UpdateSaleCommand>>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+        _mockLogger = new Mock<ILogger<UpdateSaleCommandHandler>>();
+
+        _handler = new UpdateSaleCommandHandler(
+            _mockSaleRepository.Object,
+            _mockValidator.Object,
+            _mockCurrentUserService.Object,
+            _mockLogger.Object
+        );
+    }
+
+    [Fact(DisplayName = "Should update sale payment method when all inputs are correct")]
+    public async Task Handle_WithValidInput_ShouldUpdateSaleSuccessfully()
+    {
+        // Arrange
+        var existingSale = new Domain.Entities.Sale
+        {
+            Id = new Faker().Random.Guid(),
+            AdminId = new Faker().Random.Guid(),
+            ProductId = new Faker().Random.Guid(),
+            CustomerId =new Faker().Random.Guid(),
+            EPaymentMethod = new Faker().PickRandom<EPaymentMethod>(),
+            Quantity = new Faker().Random.Int(20, 100),
+            UnitPrice = new Faker().Random.Decimal(9.99m, 599.99m)
+        };
+
+        var command = new UpdateSaleCommand(
+            existingSale.Id,
+            new Faker().PickRandom<EPaymentMethod>()
+        );
+        
+        _mockValidator
+            .Setup(va => va.ValidateAsync(
+                It.IsAny<UpdateSaleCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+        
+        _mockCurrentUserService
+            .Setup(cs => cs.GetCurrentUserId())
+            .Returns(existingSale.CustomerId.ToString());
+        
+        _mockSaleRepository
+            .Setup(sr => sr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, object>>[]>()))
+            .ReturnsAsync(existingSale);
+        
+        _mockSaleRepository
+            .Setup(sr => sr.UpdateAsync(
+                It.IsAny<Domain.Entities.Sale>(),
+                It.IsAny<CancellationToken>()));
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Data.Should().NotBeNull();
+        result.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Message.Should().ContainSingle().Which.Should().Be("Compra atualizada");
+    }
+    
+    [Fact(DisplayName = "Should return failure when sale does not exist or belongs to another customer")]
+    public async Task Handle_WithNonExistentSale_ShouldReturnFailure()
+    {
+        // Arrange
+        var command = new UpdateSaleCommand(
+            new Faker().Random.Guid(),
+            new Faker().PickRandom<EPaymentMethod>()
+        );
+        
+        _mockValidator
+            .Setup(va => va.ValidateAsync(
+                It.IsAny<UpdateSaleCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+        
+        _mockCurrentUserService
+            .Setup(cs => cs.GetCurrentUserId())
+            .Returns(new Faker().Random.Guid().ToString());
+        
+        _mockSaleRepository
+            .Setup(sr => sr.GetAsync(
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, bool>>>(),
+                It.IsAny<Expression<Func<Domain.Entities.Sale, object>>[]>()))
+            .ReturnsAsync((Domain.Entities.Sale)null!);
+        
+        _mockSaleRepository
+            .Setup(sr => sr.UpdateAsync(
+                It.IsAny<Domain.Entities.Sale>(),
+                It.IsAny<CancellationToken>()));
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Data.Should().BeNull();
+        result.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        result.Message.Should().ContainSingle().Which.Should().Be("Compra não encontrada");
+    }
+    
+    [Fact(DisplayName = "Should return failure when validation fails")]
+    public async Task Handle_WithInvalidInput_ShouldReturnValidationErrors()
+    {
+        // Arrange
+        var command = new UpdateSaleCommand(
+            new Faker().Random.Guid(),
+            new Faker().PickRandom<EPaymentMethod>()
+        );
+
+        List<ValidationFailure> validationFailure = 
+            [new("EPaymentMethod","Método de pagamento inválido")]; 
+        
+        _mockValidator
+            .Setup(va => va.ValidateAsync(
+                It.IsAny<UpdateSaleCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult(validationFailure));
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Data.Should().BeNull();
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        result.Message.Should().ContainSingle().Which.Should().Be("Método de pagamento inválido");
+    }
+}


### PR DESCRIPTION
Added comprehensive unit tests for the Sale feature command handlers:
- CreateSaleCommandHandlerTests: Test successful creation and validation failures
- UpdateSaleCommandHandlerTests: Test payment method updates and error handling
- DeleteSaleCommandHandlerTests: Test successful deletion with inventory restoration

Tests cover various scenarios including:
- Successful operations
- Validation failures
- Non-existent sales
- Insufficient product quantity
- Products that are no longer available